### PR TITLE
call `put-all!` only if the stream is open

### DIFF
--- a/src/robertluo/waterfall/core.clj
+++ b/src/robertluo/waterfall/core.clj
@@ -73,10 +73,11 @@
                     (let [assigns (.assignment consumer)]
                       (when-not (.paused consumer)
                         (.pause consumer assigns))
-                      (d/chain (ms/put-all! out-sink events)
-                               (fn [rslt]
-                                 (when rslt
-                                   (cmd-self [::resume assigns duration])))))
+                      (when-not (ms/closed? out-sink)
+                        (d/chain (ms/put-all! out-sink events)
+                                 (fn [rslt]
+                                   (when rslt
+                                     (cmd-self [::resume assigns duration]))))))
                     (cmd-self [::poll duration])))
                 
                 :else (ex-info "unknown command for consumer actor" {:cmd cmd}))) )


### PR DESCRIPTION
#21 

After the `close` call occurs, it will synchronously wait for the consumer to close. At this time, the polled message cannot be put-all! successfully.