### PR TITLE
add ::consumer-config schema to kafka-cluster

### DIFF
--- a/src/robertluo/waterfall.clj
+++ b/src/robertluo/waterfall.clj
@@ -115,6 +115,7 @@
    [:=> schema [:cat [:map {:closed true}
                       [::nodes ::nodes]
                       [::shapes [:vector [:fn shape/shape?]]]
+                      [::consumer-config {:optional true} ::consumer-config]
                       [::producer-config {:optional true} ::producer-config]
                       [::group-id {:optional true} :string]
                       [::topics {:optional true} [:vector :string]]


### PR DESCRIPTION
Closes #25 

- add missing `::consumer-config` to `waterfall/kafka-cluster`'s malli schema