### PR TITLE
add `:commit-strategy` to consumer-options

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 ;Configuration for Clojure tools.deps
 
 {:paths   ["src"]
- :deps    {manifold/manifold              {:mvn/version "0.4.1"}
+ :deps    {manifold/manifold              {:mvn/version "0.4.3"}
            org.apache.kafka/kafka-clients {:mvn/version "3.4.0" :scope "provided"} 
            org.clojure/core.match         {:mvn/version "1.0.1"}}
  :aliases {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 ;Configuration for Clojure tools.deps
 
 {:paths   ["src"]
- :deps    {manifold/manifold              {:mvn/version "0.4.3"}
+ :deps    {manifold/manifold              {:mvn/version "0.4.1"}
            org.apache.kafka/kafka-clients {:mvn/version "3.4.0" :scope "provided"} 
            org.clojure/core.match         {:mvn/version "1.0.1"}}
  :aliases {:dev

--- a/src/robertluo/waterfall.clj
+++ b/src/robertluo/waterfall.clj
@@ -97,6 +97,7 @@
     - optional `::consumer-config` can specify additional kafka consumer configuration. With additions:
       - `:position` either `:beginning` `:end`, none for commited position (default)
       - `:poll-duration` for how long the consumer poll returns, is a Duration value, default 10 seconds
+      - `:commit-strategy` one of `:sync`, `:async`, `:auto`, default `:sync`
    
    The returned map has different level of key-values let you use:
     - Highest level, no additional knowledge:


### PR DESCRIPTION
Option `:commit-strategy` added. Setting it to `:auto` will enable the auto-commit behavior.

Closes #27 